### PR TITLE
Add authentication APIs using dj-rest-auth

### DIFF
--- a/hafizhlab/api/v1/urls.py
+++ b/hafizhlab/api/v1/urls.py
@@ -1,1 +1,6 @@
-urlpatterns = []
+from django.urls import include, path
+
+urlpatterns = [
+    path('auth/', include('dj_rest_auth.urls')),
+    path('auth/registration/', include('dj_rest_auth.registration.urls')),
+]

--- a/hafizhlab/settings.py
+++ b/hafizhlab/settings.py
@@ -45,8 +45,15 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    'django.contrib.sites',
     'django.contrib.staticfiles',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
     'rest_framework',
+    'rest_framework.authtoken',
+    'dj_rest_auth',
+    'dj_rest_auth.registration',
     'hafizhlab.accounts',
 ]
 
@@ -132,6 +139,12 @@ USE_I18N = True
 USE_L10N = True
 
 USE_TZ = True
+
+
+# Site
+# https://docs.djangoproject.com/en/3.1/ref/contrib/sites/
+
+SITE_ID = 1
 
 
 # Static files (CSS, JavaScript, Images)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
 Django==3.1.5
 djangorestframework==3.12.2
 dj-database-url==0.5.0
+dj-rest-auth[with_social]==2.1.3


### PR DESCRIPTION
Added endpoints (for more information, visit [the docs](https://dj-rest-auth.readthedocs.io/en/latest/api_endpoints.html)):

- `/api/v1/auth/login/` (POST)

    - username
    - email
    - password

- `/api/v1/auth/logout/` (POST)

- `/api/v1/auth/password/reset/` (POST)

    - email

- `/api/v1/auth/password/reset/confirm/` (POST)

    - uid
    - token
    - new_password1
    - new_password2

- `/api/v1/auth/password/change/` (POST)

    - new_password1
    - new_password2
    - old_password

- `/api/v1/auth/user/` (GET, PUT, PATCH)

    - username
    - first_name
    - last_name

- `/api/v1/auth/token/verify/` (POST)

    - token

- `/api/v1/auth/token/refresh/` (POST)

    - refresh

- `/api/v1/auth/registration/` (POST)

    - username
    - password1
    - password2
    - email

- `/api/v1/auth/registration/verify-email/` (POST)

    - key